### PR TITLE
Addition of visualization scripts for AlphaFold3 outputs

### DIFF
--- a/AF3analysis-scripts/AF3-PAE.py
+++ b/AF3analysis-scripts/AF3-PAE.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# Many thanks to ChatGPT for assisting me!
+
+
+"""
+AFanalysis.py - Final version with --pdb_file support
+
+Generates PAE and pLDDT plots from AlphaFold .json files, 
+with chain boundary lines if a PDB file is provided.
+"""
+
+import argparse
+import json
+import numpy as np
+import os
+import matplotlib.pyplot as plt
+from Bio import PDB
+
+# --- Argument Parsing ---
+parser = argparse.ArgumentParser()
+parser.add_argument("--data_file", type=str, required=True, help="AlphaFold _full_data_0.json file")
+parser.add_argument("--pdb_file", type=str, help="Optional PDB file for chain boundaries")
+args = parser.parse_args()
+
+# --- Path Handling ---
+if not args.data_file.endswith("_full_data_0.json"):
+    raise ValueError("The data_file must end with '_full_data_0.json'")
+
+prefix = args.data_file.replace("_full_data_0.json", "")
+summary_file = prefix + "_summary_confidences_0.json"
+output_file = os.path.splitext(args.data_file)[0]
+
+# --- Load Data ---
+with open(args.data_file, "r") as f:
+    data = json.load(f)
+
+with open(summary_file, "r") as f:
+    summary_data = json.load(f)
+
+pae_data = data.get("pae", [])
+plddt = data.get("atom_plddts", [])
+ptm = summary_data.get("ptm", 0.0)
+iptm = summary_data.get("iptm", 0.0)
+
+# --- Chain Boundary Calculation ---
+cumulative_sum = []
+if args.pdb_file:
+    parser = PDB.PDBParser()
+    structure = parser.get_structure("AFmodel", args.pdb_file)
+    residue_counts = {}
+
+    for chain in structure.get_chains():
+        count = np.sum(np.fromiter((1 for res in chain.get_residues() if PDB.is_aa(res)), dtype=int))
+        residue_counts[chain.get_id()] = count
+
+    counts = list(residue_counts.values())
+    cumulative_sum = [sum(counts[:i+1]) for i in range(len(counts)-1)]
+
+# --- Plot PAE Matrix ---
+matrix = np.array(pae_data)
+fig, ax = plt.subplots(figsize=(7, 9))
+im = ax.imshow(matrix, cmap=plt.cm.Greens_r, vmin=0, vmax=30)
+cbar = ax.figure.colorbar(im, ax=ax, orientation='horizontal', pad=0.12)
+cbar.set_label(r"Expected position error (Ångströms)"
+               "\n"
+               "\n"
+               f"ptm={ptm:.3f}  iptm={iptm:.3f}", fontsize=18)
+cbar.ax.tick_params(labelsize=18)
+plt.xlabel("Scored residue", fontsize=18)
+plt.ylabel("Aligned residue", fontsize=18)
+for tick in cbar.ax.get_yticklabels():
+    ax.tick_params(labelsize=24)
+
+for resnum in cumulative_sum:
+    ax.axvline(x=resnum, color='darkred', linestyle='--', linewidth=2, alpha=0.5)
+    ax.axhline(y=resnum, color='darkred', linestyle='--', linewidth=2, alpha=0.5)
+
+fig.tight_layout()
+fig.savefig(f"{output_file}_PAE.jpeg", dpi=500, bbox_inches='tight')
+plt.close()
+
+# --- Plot pLDDT Graph ---
+f = plt.figure(figsize=(20, 10))
+ax = plt.gca()
+residues = list(range(1, len(plddt) + 1))
+ax.set_xlabel("Residues", fontsize=46, labelpad=10)
+ax.set_ylabel("pLDDT", fontsize=46)
+ax.plot(residues, plddt)
+ax.tick_params(labelsize=28)
+ax.get_lines()[0].set_linewidth(5)
+
+for resnum in cumulative_sum:
+    ax.axvline(x=resnum, color='darkred', linestyle='--', linewidth=2, alpha=0.5)
+
+plt.savefig(f"{output_file}_Plddt.jpeg", dpi=500, bbox_inches='tight')
+plt.close()
+
+print(f"Saved: {output_file}_PAE.jpeg and {output_file}_Plddt.jpeg")

--- a/AF3analysis-scripts/AF3-pae.py
+++ b/AF3analysis-scripts/AF3-pae.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 # Many thanks to ChatGPT for assisting me!
 
-
 """
-AFanalysis.py - Final version with --pdb_file support
+AF3-pae.py - PAE-only visualization from AlphaFold3 JSON files
 
-Generates PAE and pLDDT plots from AlphaFold .json files, 
-with chain boundary lines if a PDB file is provided.
+Generates a PAE heatmap from AlphaFold3 _full_data_0.json and 
+_summary_confidences_0.json. Adds chain boundary lines if a PDB file is provided.
 """
 
 import argparse
@@ -18,7 +17,7 @@ from Bio import PDB
 
 # --- Argument Parsing ---
 parser = argparse.ArgumentParser()
-parser.add_argument("--data_file", type=str, required=True, help="AlphaFold _full_data_0.json file")
+parser.add_argument("--data_file", type=str, required=True, help="AlphaFold3 _full_data_0.json file")
 parser.add_argument("--pdb_file", type=str, help="Optional PDB file for chain boundaries")
 args = parser.parse_args()
 
@@ -38,7 +37,6 @@ with open(summary_file, "r") as f:
     summary_data = json.load(f)
 
 pae_data = data.get("pae", [])
-plddt = data.get("atom_plddts", [])
 ptm = summary_data.get("ptm", 0.0)
 iptm = summary_data.get("iptm", 0.0)
 
@@ -60,17 +58,22 @@ if args.pdb_file:
 matrix = np.array(pae_data)
 fig, ax = plt.subplots(figsize=(7, 9))
 im = ax.imshow(matrix, cmap=plt.cm.Greens_r, vmin=0, vmax=30)
+
+# Add colorbar and labels
 cbar = ax.figure.colorbar(im, ax=ax, orientation='horizontal', pad=0.12)
 cbar.set_label(r"Expected position error (Ångströms)"
                "\n"
                "\n"
                f"ptm={ptm:.3f}  iptm={iptm:.3f}", fontsize=18)
 cbar.ax.tick_params(labelsize=18)
+
 plt.xlabel("Scored residue", fontsize=18)
 plt.ylabel("Aligned residue", fontsize=18)
+
 for tick in cbar.ax.get_yticklabels():
     ax.tick_params(labelsize=24)
 
+# Add chain boundary lines
 for resnum in cumulative_sum:
     ax.axvline(x=resnum, color='darkred', linestyle='--', linewidth=2, alpha=0.5)
     ax.axhline(y=resnum, color='darkred', linestyle='--', linewidth=2, alpha=0.5)
@@ -79,20 +82,4 @@ fig.tight_layout()
 fig.savefig(f"{output_file}_PAE.jpeg", dpi=500, bbox_inches='tight')
 plt.close()
 
-# --- Plot pLDDT Graph ---
-f = plt.figure(figsize=(20, 10))
-ax = plt.gca()
-residues = list(range(1, len(plddt) + 1))
-ax.set_xlabel("Residues", fontsize=46, labelpad=10)
-ax.set_ylabel("pLDDT", fontsize=46)
-ax.plot(residues, plddt)
-ax.tick_params(labelsize=28)
-ax.get_lines()[0].set_linewidth(5)
-
-for resnum in cumulative_sum:
-    ax.axvline(x=resnum, color='darkred', linestyle='--', linewidth=2, alpha=0.5)
-
-plt.savefig(f"{output_file}_Plddt.jpeg", dpi=500, bbox_inches='tight')
-plt.close()
-
-print(f"Saved: {output_file}_PAE.jpeg and {output_file}_Plddt.jpeg")
+print(f"Saved: {output_file}_PAE.jpeg")

--- a/AF3analysis-scripts/AF3-plddt-colored.py
+++ b/AF3analysis-scripts/AF3-plddt-colored.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Many thanks to ChatGPT for assisting me!
+
+import argparse
+import matplotlib.pyplot as plt
+
+def read_plddt_from_pdb(pdb_file):
+    """
+    Parse a PDB file, extracting one pLDDT per residue from the B-factor column.
+    Also detect chain breaks whenever the chain ID changes.
+    Returns (residue_indices, plddt_list, chain_break_positions).
+    """
+    residues = []
+    plddt = []
+    chain_breaks = []
+
+    prev_chain = None
+    prev_resseq = None
+    counter = 0
+
+    with open(pdb_file) as f:
+        for line in f:
+            if not line.startswith("ATOM"):
+                continue
+            chain = line[21]
+            resseq = int(line[22:26])
+            bfact = float(line[60:66])
+
+            # new residue when either chain or residue number changes
+            if (chain, resseq) != (prev_chain, prev_resseq):
+                counter += 1
+                residues.append(counter)
+                plddt.append(bfact)
+
+                if prev_chain is not None and chain != prev_chain:
+                    # mark break at end of previous chain
+                    chain_breaks.append(counter - 1)
+
+                prev_chain = chain
+                prev_resseq = resseq
+
+    return residues, plddt, chain_breaks
+
+def plot_plddt(residues, plddt, breaks, out_prefix):
+    fig, ax = plt.subplots(figsize=(20, 10))
+
+    # --- AlphaFold DB confidence bands ---
+    ax.fill_between(residues, 0, 50,   color='#ff7f0e', alpha=0.2, label='Very Low (0–50)')
+    ax.fill_between(residues, 50, 70,  color='#bcbd22', alpha=0.2, label='Low (50–70)')
+    ax.fill_between(residues, 70, 90,  color='#17becf', alpha=0.2, label='High (70–90)')
+    ax.fill_between(residues, 90, 100, color='#1f77b4', alpha=0.2, label='Very High (90–100)')
+    
+    # pLDDT trace
+    ax.plot(residues, plddt, linewidth=5, color='black', label='pLDDT')
+
+    # chain‐break lines
+    for b in breaks:
+        ax.axvline(x=b, color='darkred', linestyle='--', linewidth=2, alpha=0.5)
+
+    # gray dashed thresholds
+    for y in (50, 70, 90):
+        ax.axhline(y=y, color='gray', linestyle='--', linewidth=1.5)
+
+    # labels, limits & ticks
+    ax.set_xlabel("Residue", fontsize=46, labelpad=10)
+    ax.set_ylabel("pLDDT", fontsize=46)
+    ax.set_ylim(0, 100)
+    ax.set_yticks(range(0, 101, 10))
+    ax.tick_params(labelsize=28)
+
+    ax.legend(loc='upper right', fontsize=24)
+    plt.tight_layout()
+
+    out_file = f"{out_prefix}_plddt.jpeg"
+    fig.savefig(out_file, dpi=500, bbox_inches='tight')
+    plt.close(fig)
+
+    print(f"Saved pLDDT plot to: {out_file}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Plot AF3 pLDDT directly from a PDB")
+    parser.add_argument("--pdb_file",
+                        help="Path to your AF3 PDB (pLDDT in B-factor)",
+                        required=True)
+    parser.add_argument("--out_prefix",
+                        help="Prefix for output files (default: AF3)",
+                        default="AF3")
+    args = parser.parse_args()
+
+    residues, plddt, chain_breaks = read_plddt_from_pdb(args.pdb_file)
+    plot_plddt(residues, plddt, chain_breaks, args.out_prefix)
+
+if __name__ == "__main__":
+    main()

--- a/AF3analysis-scripts/AF3-plddt.py
+++ b/AF3analysis-scripts/AF3-plddt.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Many thanks to ChatGPT for assisting me!
+
+import argparse
+import os
+import matplotlib.pyplot as plt
+
+def read_plddt_from_pdb(pdb_file):
+    residues = []
+    plddt = []
+    chain_breaks = []
+
+    prev_chain = None
+    prev_resseq = None
+    counter = 0
+
+    with open(pdb_file) as f:
+        for line in f:
+            if not line.startswith("ATOM"):
+                continue
+            chain = line[21]
+            resseq = int(line[22:26])
+            bfact = float(line[60:66])
+
+            if (chain, resseq) != (prev_chain, prev_resseq):
+                counter += 1
+                residues.append(counter)
+                plddt.append(bfact)
+
+                if prev_chain is not None and chain != prev_chain:
+                    chain_breaks.append(counter - 1)
+
+                prev_chain = chain
+                prev_resseq = resseq
+
+    return residues, plddt, chain_breaks
+
+def plot_plddt(residues, plddt, breaks, pdb_file):
+    fig, ax = plt.subplots(figsize=(20, 10))
+
+    # pLDDT trace
+    ax.plot(residues, plddt, linewidth=5, color='blue', label='pLDDT')
+
+    # chain‐break lines
+    for b in breaks:
+        ax.axvline(x=b, color='darkred', linestyle='--', linewidth=2, alpha=0.5)
+
+    # gray dashed thresholds
+    for y in (50, 70, 90):
+        ax.axhline(y=y, color='gray', linestyle='--', linewidth=1.5)
+
+    ax.set_xlabel("Residue", fontsize=46, labelpad=10)
+    ax.set_ylabel("pLDDT", fontsize=46)
+    ax.set_ylim(0, 100)
+    ax.set_yticks(range(0, 101, 10))
+    ax.tick_params(labelsize=28)
+
+    ax.legend(loc='upper right', fontsize=24)
+    plt.tight_layout()
+
+    pdb_name = os.path.splitext(os.path.basename(pdb_file))[0]
+    out_file = f"{pdb_name}_plddt.jpeg"
+    fig.savefig(out_file, dpi=500, bbox_inches='tight')
+    plt.close(fig)
+
+    print(f"Saved pLDDT plot to: {out_file}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Plot AF3 pLDDT directly from a PDB")
+    parser.add_argument("--pdb_file", help="Path to your AF3 PDB (pLDDT in B-factor)", required=True)
+    args = parser.parse_args()
+
+    residues, plddt, chain_breaks = read_plddt_from_pdb(args.pdb_file)
+    plot_plddt(residues, plddt, chain_breaks, args.pdb_file)
+
+if __name__ == "__main__":
+    main()
+

--- a/AF3analysis-scripts/AF3-plddt.py
+++ b/AF3analysis-scripts/AF3-plddt.py
@@ -38,26 +38,23 @@ def read_plddt_from_pdb(pdb_file):
 def plot_plddt(residues, plddt, breaks, pdb_file):
     fig, ax = plt.subplots(figsize=(20, 10))
 
-    # pLDDT trace
-    ax.plot(residues, plddt, linewidth=5, color='blue', label='pLDDT')
+    # Draw a single uniform pLDDT trace
+    ax.plot(residues, plddt, linewidth=5, color='steelblue')
 
-    # chain‐break lines
+    # Chain-break vertical dashed lines
     for b in breaks:
         ax.axvline(x=b, color='darkred', linestyle='--', linewidth=2, alpha=0.5)
 
-    # gray dashed thresholds
-    for y in (50, 70, 90):
-        ax.axhline(y=y, color='gray', linestyle='--', linewidth=1.5)
-
-    ax.set_xlabel("Residue", fontsize=46, labelpad=10)
+    # Axes and styling
+    ax.set_xlabel("Residues", fontsize=46, labelpad=10)
     ax.set_ylabel("pLDDT", fontsize=46)
     ax.set_ylim(0, 100)
     ax.set_yticks(range(0, 101, 10))
     ax.tick_params(labelsize=28)
 
-    ax.legend(loc='upper right', fontsize=24)
     plt.tight_layout()
 
+    # Save output
     pdb_name = os.path.splitext(os.path.basename(pdb_file))[0]
     out_file = f"{pdb_name}_plddt.jpeg"
     fig.savefig(out_file, dpi=500, bbox_inches='tight')
@@ -66,7 +63,7 @@ def plot_plddt(residues, plddt, breaks, pdb_file):
     print(f"Saved pLDDT plot to: {out_file}")
 
 def main():
-    parser = argparse.ArgumentParser(description="Plot AF3 pLDDT directly from a PDB")
+    parser = argparse.ArgumentParser(description="Plot AF3 pLDDT from PDB with a single consistent color")
     parser.add_argument("--pdb_file", help="Path to your AF3 PDB (pLDDT in B-factor)", required=True)
     args = parser.parse_args()
 
@@ -75,4 +72,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Generates:
 
 **Usage:**
 ```
-python AF3-PAE.py --data_file model_full_data_0.json --pdb_file model.pdb```
+	python AF3-PAE.py --data_file model_full_data_0.json --pdb_file model.pdb
+```
 
 ### `AF3-plddt.py`
 
@@ -59,7 +60,8 @@ Generates:
 **Usage:**
 
 ```
-python AF3-plddt.py --pdb_file model.pdb```
+	python AF3-plddt.py --pdb_file model.pdb
+```
 
 ### `AF3-plddt-colored.py`
 
@@ -79,7 +81,8 @@ Very High (90–100) Blue
 Usage:
 
 ```
-python AF3-plddt-colored.py --pdb_file model.pdb --out_prefix model```
+	python AF3-plddt-colored.py --pdb_file model.pdb --out_prefix model
+```
 
 Recommended to use these scripts by creating a conda environment.
 ```

--- a/README.md
+++ b/README.md
@@ -16,45 +16,76 @@ With this script, you can only analyze one AlphaFold model at a time.
 	If both pkl/json and pdb files are provided, this script outputs:
 	- All mentioned above and updated versions of PAE and pLDDT graphs showing the residue numbers of each monomers as lines. 
 
-Usage: 
+**Usage: **
 ```
 	python AFanalysis.py --data_file <pkl file or json file>
 	python AFanalysis.py --pdb_file <pdb file>
 	or 
 	python AFanalysis.py --data_file <pkl file or json file> --pdb_file <pdb file>
 ```
-	
-Example: 
-```
-	python AFanalysis.py --data_file result_model_1_multimer_v2_pred_1.pkl
-	python AFanalysis.py --data_file result_model_1_multimer_v2_pred_1.json
-	python AFanalysis.py --pdb_file rank0.pdb
-	python AFanalysis.py --data_file result_model_1_multimer_v2_pred_1.pkl --input_pdb rank0.pdb
-	python AFanalysis.py --data_file result_model_1_multimer_v2_pred_1.json --input_pdb rank0.pdb
-```
 
-Recommended to use this script by creating a conda environment.
+# AF3analysis: AlphaFold3 Model Confidence Visualizations Scripts
+
+This repository provides tools for analyzing and visualizing model confidence scores from AlphaFold and AlphaFold3, including:
+
+- **Predicted Aligned Error (PAE)** matrices
+- **Per-residue pLDDT** confidence plots
+- Optional **chain break visualization** using PDB files
+- Compatible with AlphaFold3 `.json` and `.pdb` outputs
+
+---
+
+## Scripts
+
+### `AF3-PAE.py`
+
+Generates:
+- A **PAE matrix** using `_full_data_0.json`
+- A **pLDDT line plot** from the same JSON
+- Optional vertical chain break lines (if a PDB file is provided)
+
+**Usage:**
+```
+python AF3-PAE.py --data_file model_full_data_0.json --pdb_file model.pdb```
+
+### `AF3-plddt.py`
+
+Generates:
+
+- A **per-residue pLDDT plot** using values from the B-factor column of an AlphaFold3-generated PDB file
+- A **clean line graph**, without background confidence bands
+- Optional vertical chain break lines based on changes in chain ID
+
+**Usage:**
+
+```
+python AF3-plddt.py --pdb_file model.pdb```
+
+### `AF3-plddt-colored.py`
+
+Generates:
+
+- A **per-residue pLDDT plot* using values from the B-factor column of a PDB file
+
+- A **confidence-colored** background showing AlphaFold-style score bands:
+
+Very Low (0–50) Orange
+Low (50–70) Yellow
+High (70–90) Cyan Blue
+Very High (90–100) Blue
+
+- Optional vertical chain break lines based on changes in chain ID
+
+Usage:
+
+```
+python AF3-plddt-colored.py --pdb_file model.pdb --out_prefix model```
+
+Recommended to use these scripts by creating a conda environment.
 ```
 	conda create -n AFanalysis python=3.7
 	conda activate AFanalysis
 	conda install -c schrodinger pymol -y
 	conda install matplotlib
 ```
-
-Output figure examples are listed below: 
-
-- PAE graphs (with and without residue numbers of monomers):
-
-<img src="https://user-images.githubusercontent.com/62547137/230650827-6aecf698-285b-4fd7-b2e1-c33d4e4fc0fd.jpeg" width="370" height="400"><img src="https://user-images.githubusercontent.com/62547137/230651275-01160bd3-3372-4102-898b-68767532f450.jpeg" width="370" height="400">
-
-
-- pLDDT graphs (with and without residue numbers of monomers):
-
-<img src="https://user-images.githubusercontent.com/62547137/230650807-575f5178-f1af-4108-8545-43005fa545b9.jpeg" width="400" height="200"><img src="https://user-images.githubusercontent.com/62547137/230651186-4a51cd95-bc12-40f7-a24d-3a85be39e5f1.jpeg" width="400" height="200">
-
-- PyMOL-made figures:
-
-<img src="https://user-images.githubusercontent.com/62547137/230650419-808b7340-1d56-4c2b-bb09-004e66e49687.png" width="400" height="370"><img src="https://user-images.githubusercontent.com/62547137/230650456-964bcbc0-77e1-48c9-b26c-7ff726e01a55.png" width="400" height="370">
-
-
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AFanalysis
+# AFanalysis: AlphaFold2 Model Confidence Visualization Script
 
 Here, you can use the provided python script for the analysis of AlphaFold models, including both local predictions that produce .pkl files and ColabFold predictions that produce .json files storing quality evaluation scores. 
 

--- a/README.md
+++ b/README.md
@@ -88,4 +88,3 @@ Recommended to use these scripts by creating a conda environment.
 	conda install -c schrodinger pymol -y
 	conda install matplotlib
 ```
-

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ This repository provides tools for analyzing and visualizing model confidence sc
 
 ## Scripts
 
-### `AF3-PAE.py`
+### `AF3-pae.py`
 
 Generates:
 - A **PAE matrix** using `_full_data_0.json`
 - A **pLDDT line plot** from the same JSON
 - Optional vertical chain break lines (if a PDB file is provided)
-
+- 
 **Usage:**
 ```
 	python AF3-PAE.py --data_file model_full_data_0.json --pdb_file model.pdb


### PR DESCRIPTION
This pull request adds new scripts for analyzing and visualizing AlphaFold3 model outputs, including per-residue confidence plots and predicted aligned error (PAE) matrices. The scripts support visualization directly from AlphaFold3 .json files and .pdb files.

What's New
AF3-PAE.py:

Generates PAE matrices from *_full_data_0.json.
Plots pLDDT scores from JSON.
Optionally adds chain boundary lines from PDB files.

AF3-plddt.py:

Extracts per-residue pLDDT scores from the PDB B-factor column.
Creates a clean pLDDT line plot without background shading.
Optionally adds chain break markers.

AF3-plddt-colored.py:

Similar to AF3-plddt.py, but includes AlphaFold-style background confidence bands:
Very Low (0–50) → Orange
Low (50–70) → Yellow-Green
High (70–90) → Cyan
Very High (90–100) → Blue

Updated README.md:

Detailed instructions for usage.
Installation instructions.
Consistent format for all scripts.
Added recommended folder structure.

Benefits
Provides seamless visualization tools for AlphaFold3 outputs.
Supports both JSON and PDB inputs.
Clean plots ready for publication or analysis.
Consistent styling and documentation.

Notes
Scripts require: matplotlib, numpy, biopython.
Python 3.6+ compatible.